### PR TITLE
Fix CopyPlugin and Improve documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ require('laravel-mix-imagemin');
 
 mix
     .js('resources/js/app.js', 'public/js')
-    .imagemin('img/*');
+    .imagemin('img');
 ```
 
 ## Configuration
@@ -45,9 +45,11 @@ require('laravel-mix-imagemin');
 mix
     .js('resources/js/app.js', 'public/js')
     .imagemin(
-        'img/**.*',
+        'img',
         {
-            context: 'resources',
+            from: 'img',
+            to: 'another-image-path',
+            context: 'resources'
         },
         {
             optipng: {

--- a/src/Imagemin.js
+++ b/src/Imagemin.js
@@ -13,15 +13,25 @@ class Imagemin {
 
         return ['copy-webpack-plugin', 'imagemin-webpack-plugin'];
     }
-    
+
     register(patterns, copyOptions = {}, imageminOptions = {}) {
         this.patterns = [].concat(patterns);
-        
+
+        let copyPatterns = [];
+        for (var i = 0; i < this.patterns.length; i++) {
+            const pattern = this.patterns[i].replace(/^\/+/g, '');
+
+            copyPatterns.push({
+                from: pattern,
+                to: pattern,
+                context: 'resources'
+            });
+        }
+
         this.copyOptions = Object.assign({
-            from: 'resources',
-            to: 'public'
+            patterns: copyPatterns,
         }, copyOptions);
-        
+
         this.imageminOptions = Object.assign({
             test: /\.(jpe?g|png|gif|svg)$/i,
         }, imageminOptions);

--- a/src/Imagemin.js
+++ b/src/Imagemin.js
@@ -13,10 +13,15 @@ class Imagemin {
 
         return ['copy-webpack-plugin', 'imagemin-webpack-plugin'];
     }
-
+    
     register(patterns, copyOptions = {}, imageminOptions = {}) {
         this.patterns = [].concat(patterns);
-        this.copyOptions = copyOptions;
+        
+        this.copyOptions = Object.assign({
+            from: 'resources',
+            to: 'public'
+        }, copyOptions);
+        
         this.imageminOptions = Object.assign({
             test: /\.(jpe?g|png|gif|svg)$/i,
         }, imageminOptions);
@@ -28,7 +33,7 @@ class Imagemin {
         let {patterns, copyOptions, imageminOptions} = this;
 
         return [
-            new CopyWebpackPlugin(patterns, copyOptions),
+            new CopyWebpackPlugin(copyOptions),
             new ImageminPlugin(imageminOptions),
             new ManifestPlugin(patterns),
         ];


### PR DESCRIPTION
Hi!
I guess this PR fixes #9 #11 #13 

I'm using this very well to place a "images" directory under resources with just `mix.imagemin('images');` as configuration.